### PR TITLE
Add haproxy-lb service as entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ version: '3'
 services:
   nginx-web:
     image: codertravel/nginx-web:latest
-    ports:
-      - "8080:80"
 
   haproxy-lb:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,11 @@ services:
     image: codertravel/nginx-web:latest
     ports:
       - "80:80"
+
+  haproxy-lb:
+    build:
+      context: ./haproxy-lb
+      dockerfile: Dockerfile
+    image: haproxy-lb
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   nginx-web:
     image: codertravel/nginx-web:latest
     ports:
-      - "80:80"
+      - "8080:80"
 
   haproxy-lb:
     build:
@@ -12,4 +12,4 @@ services:
       dockerfile: Dockerfile
     image: haproxy-lb
     ports:
-      - "8080:8080"
+      - "80:80"

--- a/haproxy-lb/Dockerfile
+++ b/haproxy-lb/Dockerfile
@@ -1,0 +1,3 @@
+FROM haproxy:2.5
+
+COPY ./haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/haproxy-lb/Dockerfile
+++ b/haproxy-lb/Dockerfile
@@ -1,3 +1,3 @@
-FROM haproxy:2.5
+FROM haproxy:2.5-alpine
 
 COPY ./haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/haproxy-lb/haproxy.cfg
+++ b/haproxy-lb/haproxy.cfg
@@ -1,4 +1,5 @@
 global
+    log stdout format rfc5424 daemon debug
     user haproxy
     group haproxy
     daemon

--- a/haproxy-lb/haproxy.cfg
+++ b/haproxy-lb/haproxy.cfg
@@ -1,0 +1,18 @@
+global
+    user haproxy
+    group haproxy
+    daemon
+
+defaults
+    log global
+    mode http
+    timeout connect 5000
+    timeout client  50000
+    timeout server  50000
+
+frontend loadbalancer
+    bind *:80
+    default_backend nginx-web
+
+backend nginx-web
+    server nginx-web nginx-web:80


### PR DESCRIPTION
Make `nginx-web` service unavailable for direct access.
Create `haproxy-lb` service and forward its traffic on port `80` to `nginx-web` service.
Allow access to `haproxy-lb` on port `80`.