### PR TITLE
Add high availability for nginx-web service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,12 @@
 version: '3'
 
 services:
-  nginx-web:
+  nginx-web-1:
     image: codertravel/nginx-web:latest
+    restart: always
+  nginx-web-2:
+    image: codertravel/nginx-web:latest
+    restart: always
 
   haproxy-lb:
     build:
@@ -11,3 +15,4 @@ services:
     image: haproxy-lb
     ports:
       - "80:80"
+    restart: always

--- a/haproxy-lb/haproxy.cfg
+++ b/haproxy-lb/haproxy.cfg
@@ -16,4 +16,4 @@ frontend loadbalancer
     default_backend nginx-web
 
 backend nginx-web
-    server nginx-web nginx-web:80
+    server nginx-web-1 nginx-web-1:80

--- a/haproxy-lb/haproxy.cfg
+++ b/haproxy-lb/haproxy.cfg
@@ -16,4 +16,6 @@ frontend loadbalancer
     default_backend nginx-web
 
 backend nginx-web
-    server nginx-web-1 nginx-web-1:80
+    balance roundrobin
+    server nginx-web-1 nginx-web-1:80 check
+    server nginx-web-2 nginx-web-2:80 check


### PR DESCRIPTION
Add another `nginx-web` instance.
Configure `haproxy-lb` to spread traffic between `nginx-web-1` and `nginx-web-2` instances.
Spread traffic using round robin algorithm.